### PR TITLE
added code for controlling regular expression compile flags

### DIFF
--- a/clinical_sectionizer/text_sectionizer.py
+++ b/clinical_sectionizer/text_sectionizer.py
@@ -3,9 +3,11 @@ import re
 # Filepath to default rules which are included in package
 from os import path
 from pathlib import Path
+
 DEFAULT_RULES_FILEPATH = path.join(
     Path(__file__).resolve().parents[1], "resources", "text_section_patterns.jsonl"
 )
+
 
 class TextSectionizer:
     name = "text_sectionizer"
@@ -18,30 +20,58 @@ class TextSectionizer:
         if patterns is not None:
             if patterns == "default":
                 import os
+
                 if not os.path.exists(DEFAULT_RULES_FILEPATH):
-                    raise FileNotFoundError("The expected location of the default patterns file cannot be found. Please either "
-                                            "add patterns manually or add a jsonl file to the following location: ",
-                                            DEFAULT_RULES_FILEPATH)
+                    raise FileNotFoundError(
+                        "The expected location of the default patterns file cannot be found. Please either "
+                        "add patterns manually or add a jsonl file to the following location: ",
+                        DEFAULT_RULES_FILEPATH,
+                    )
                 self.add(self.load_patterns_from_jsonl(DEFAULT_RULES_FILEPATH))
             # If a list, add each of the patterns in the list
             elif isinstance(patterns, list):
                 self.add(patterns)
             elif isinstance(patterns, str):
                 import os
+
                 assert os.path.exists(patterns)
                 self.add(self.load_patterns_from_jsonl(patterns))
 
-    def add(self, patterns):
+    def add(self, patterns, cflags=None):
+        """
+        Add compiled regular expressions defined in patterns
+
+        Positional arguments:
+        - patterns --
+
+        Keyword arguments:
+        - cflags -- a list of regular expression compile flags
+                 If cflags==None then cflags is set to [re.I]
+        """
+
+        def _mycomp(rex, flags=None):
+
+            if flags == None:
+                flags = [re.I]
+            cflags = 0
+            for f in flags:
+                if isinstance(f, re.RegexFlag):
+                    cflags = cflags | f
+            return re.compile(rex, flags=cflags)
+
         for pattern_dict in patterns:
             name = pattern_dict["section_title"]
             pattern = pattern_dict["pattern"]
             if isinstance(pattern, str):
                 self._compiled_patterns.setdefault(name, [])
-                self._compiled_patterns[name].append(re.compile(pattern, re.IGNORECASE))
+                self._compiled_patterns[name].append(_mycomp(pattern, flags=cflags))
             else:
                 # TODO: Change the default patterns
                 # continue
-                raise ValueError("Patterns added to the TextSectionizer must be strings", pattern_dict)
+                raise ValueError(
+                    "Patterns added to the TextSectionizer must be strings",
+                    pattern_dict,
+                )
             self._patterns.append(pattern_dict)
             self._section_titles.add(name)
 
@@ -57,6 +87,7 @@ class TextSectionizer:
     def load_patterns_from_jsonl(self, filepath):
 
         import json
+
         patterns = []
         with open(filepath) as f:
             for line in f:
@@ -82,21 +113,20 @@ class TextSectionizer:
         # If the first section doesn't start at the very beginning,
         # add an unknown section at the beginning
         if matches[0][1].start() != 0:
-            sections.append((None, None, text[:matches[0][1].start()]))
+            sections.append((None, None, text[: matches[0][1].start()]))
 
         for i, (section_title, match) in enumerate(matches):
             section_header = match.group()
             # If this is the final section, it should include the rest of the text
             if i == len(matches) - 1:
-                section_text = text[match.start():]
+                section_text = text[match.start() :]
                 sections.append((section_title, section_header, section_text))
             # Otherwise, it will include all of the text up until the next section header
             else:
                 next_match = matches[i + 1][1]
-                section_text = text[match.start():next_match.start()]
+                section_text = text[match.start() : next_match.start()]
                 sections.append((section_title, section_header, section_text))
         return sections
-
 
     def extract_sections(self, text):
         matches = []
@@ -113,13 +143,13 @@ class TextSectionizer:
 
         sections = []
         if matches[0][1].start() != 0:
-            sections.append(("UNK", text[:matches[0][1].start()]))
+            sections.append(("UNK", text[: matches[0][1].start()]))
         for i, (name, match) in enumerate(matches):
             if i == len(matches) - 1:
-                sections.append((name, text[match.start():]))
+                sections.append((name, text[match.start() :]))
             else:
                 next_match = matches[i + 1][1]
-                sections.append((name, text[match.start():next_match.start()]))
+                sections.append((name, text[match.start() : next_match.start()]))
 
         return sections
 

--- a/notebooks/with_compile_flags.ipynb
+++ b/notebooks/with_compile_flags.ipynb
@@ -1,0 +1,188 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from add_parent_path import add_parent_path\n",
+    "\n",
+    "with add_parent_path(1):\n",
+    "    from clinical_sectionizer import TextSectionizer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text = \"\"\"\n",
+    "     FINDINGS:  Compared to the prior days study, there is stable appearance of the\n",
+    "     right parietal intraparenchymal hemorrhage with surrounding edema.  At the\n",
+    "     superior margin of the parenchymal hemorrhage there is a rounded heterogeneous\n",
+    "     focus which could represent a metastatic lesion.  An additional 2mm hyperdense\n",
+    "     focus, possibly hemorrhage, is noted in the posteromedial margin of the left\n",
+    "     thalamus, with surroundng edema.  Low-attenuation foci seen in both basal\n",
+    "     ganglia and insular regions are consistent with chronic lacunar infarcts.\n",
+    "     There is no shift of midline structures.  The ventricles are stable in\n",
+    "     appearance.  The osseous and soft tissue structures are unremarkable.\n",
+    "     \n",
+    "     IMPRESSION:  Stable appearance of right parietal lobe and left thalamic\n",
+    "     hemorrhages, which are concerning for hemorrhagic metastasis in this patient\n",
+    "     with known metastatic lung carcinoma to the brain.\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### By default section detection is done ignoring case (`re.I`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sectionizer = TextSectionizer(patterns=None)\n",
+    "\n",
+    "rad_patterns = [{'section_title': 'impression', \n",
+    "                 'pattern':'impression:'},]\n",
+    "\n",
+    "sectionizer.add(rad_patterns)\n",
+    "sections = sectionizer(text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Text is split into two parts: before and after section"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(sections)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('impression',\n",
+       " 'IMPRESSION:',\n",
+       " 'IMPRESSION:  Stable appearance of right parietal lobe and left thalamic\\n     hemorrhages, which are concerning for hemorrhagic metastasis in this patient\\n     with known metastatic lung carcinoma to the brain.')"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sections[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Create regular expression without `re.I` flag"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sectionizer = TextSectionizer(patterns=None)\n",
+    "\n",
+    "rad_patterns = [{'section_title': 'impression', \n",
+    "                 'pattern':'impression:'},]\n",
+    "\n",
+    "sectionizer.add(rad_patterns, cflags=[])\n",
+    "sections = sectionizer(text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Section not detected\n",
+    "\n",
+    "Only one section in result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(sections)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/test_textsectionizer.py
+++ b/tests/test_textsectionizer.py
@@ -1,0 +1,89 @@
+import pytest
+from add_parent_path import add_parent_path
+
+with add_parent_path(1):
+    from clinical_sectionizer import TextSectionizer
+
+
+class TestTextSectionizer:
+    def test_add(self):
+        sectionizer = TextSectionizer(patterns=None)
+        sectionizer.add([{"section_title": "section", "pattern": "my pattern"}])
+        assert sectionizer.patterns
+
+    def test_add_wo_flag(self):
+        sectionizer = TextSectionizer(patterns=None)
+        sectionizer.add(
+            [{"section_title": "section", "pattern": "my pattern"}], cflags=[]
+        )
+        assert sectionizer.patterns
+
+    def test_string_match(self):
+        sectionizer = TextSectionizer(patterns=None)
+        sectionizer.add(
+            [
+                {
+                    "section_title": "past_medical_history",
+                    "pattern": "Past Medical History:",
+                }
+            ]
+        )
+        doc = "Past Medical History: PE"
+        sections = sectionizer(doc)
+        (section_title, header, section) = sections[0]
+        assert section_title == "past_medical_history"
+        assert header == "Past Medical History:"
+        assert section == "Past Medical History: PE"
+
+    def test_string_match_case_sensitive(self):
+        sectionizer = TextSectionizer(patterns=None)
+        sectionizer.add(
+            [
+                {
+                    "section_title": "past_medical_history",
+                    "pattern": "PAST MEDICAL HISTORY:",
+                }
+            ],
+            cflags=[],
+        )
+        doc = "Past Medical History: PE"
+        sections = sectionizer(doc)
+        (section_title, header, section) = sections[0]
+        assert section_title == None
+        assert header == None
+
+    def test_string_match_case_sensitive2(self):
+        sectionizer = TextSectionizer(patterns=None)
+        sectionizer.add(
+            [
+                {
+                    "section_title": "past_medical_history",
+                    "pattern": "PAST MEDICAL HISTORY:",
+                }
+            ],
+            cflags=[],
+        )
+        doc = "PAST MEDICAL HISTORY: PE"
+        sections = sectionizer(doc)
+        (section_title, header, section) = sections[0]
+        assert section_title == "past_medical_history"
+        assert header == "PAST MEDICAL HISTORY:"
+        assert section == "PAST MEDICAL HISTORY: PE"
+
+        def test_string_match_case_sensitive3(self):
+            sectionizer = TextSectionizer(patterns=None)
+            sectionizer.add(
+                [
+                    {
+                        "section_title": "past_medical_history",
+                        "pattern": "PAST MEDICAL HISTORY:",
+                    }
+                ],
+                cflags=[],
+            )
+            doc = "PAST MEDICAL HISTORY: PE"
+            sections = sectionizer(doc)
+            (section_title, header, section) = sections[0]
+            assert section_title == "past_medical_history"
+            assert header == "Past Medical History:"
+            assert section == "Past Medical History: PE"


### PR DESCRIPTION
By default everything runs as before, with re.I provided at regex compilation but can now provide a list of flags to compile with, including the empty list.

Test uses add_parent_path